### PR TITLE
Improvement the collection of statistics

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -142,7 +142,7 @@ return {
 		d2 = {'bot:groupsid', 'bot:groupsid:removed', 'tempbanned', 'bot:blocked', 'remolden_chats'} --remolden_chats: chat removed with $remold command
 	},
 	api_errors = {
-		[101] = 'Not enough rights to kick participant', --SUPERGROUP: bot is not admin
+		[101] = 'Not enough rights to kick/unban chat member', --SUPERGROUP: bot is not admin
 		[102] = 'USER_ADMIN_INVALID', --SUPERGROUP: trying to kick an admin
 		[103] = 'method is available for supergroup chats only', --NORMAL: trying to unban
 		[104] = 'Only creator of the group can kick administrators from the group', --NORMAL: trying to kick an admin

--- a/methods.lua
+++ b/methods.lua
@@ -103,6 +103,7 @@ function api.kickChatMember(chat_id, user_id)
 		return false, tab.description
 	end
 	
+	db:srem(string.format('chat:%d:members', chat_id), user_id)
 	return tab
 
 end
@@ -207,6 +208,7 @@ function api.leaveChat(chat_id)
 	
 	if res then
 		db:hincrby('bot:general', 'groups', -1)
+		db:srem(string.format('chat:%d:members', chat_id), bot.id)
 	end
 	
 	return res, code

--- a/plugins/admin.lua
+++ b/plugins/admin.lua
@@ -420,7 +420,7 @@ local action = function(msg, blocks)
 		api.sendAdmin(msg.chat.id)
 	end
 	if blocks[1] == 'remban' then
-		local user_id = misc.res_user(blocks[2])
+		local user_id = misc.resolve_user(blocks[2])
 		local text
 		if user_id then
 			db:del('ban:'..user_id)

--- a/plugins/users.lua
+++ b/plugins/users.lua
@@ -41,7 +41,7 @@ local function get_user_id(msg, blocks)
 		return msg.reply.from.id
 	elseif blocks[2] then
 		if blocks[2]:match('@[%w_]+$') then --by username
-			local user_id = misc.res_user_group(blocks[2], msg.chat.id)
+			local user_id = misc.resolve_user(blocks[2])
 			if not user_id then
 				print('username (not found)')
 				return false

--- a/utilities.lua
+++ b/utilities.lua
@@ -520,6 +520,7 @@ function misc.getSettings(chat_id)
 		Welcome = _("Welcome message"),
 		Extra = _("Extra"),
 		Flood = _("Anti-flood"),
+		Antibot = _("Ban bots"),
 		Silent = _("Silent mode"),
 		Rules = _("Rules"),
 		Arab = _("Arab"),

--- a/utilities.lua
+++ b/utilities.lua
@@ -200,36 +200,19 @@ function misc.get_date(timestamp)
 	return os.date('%d/%m/%y')
 end
 
-function misc.res_user(username)
-	local hash = 'bot:usernames'
-	local stored = db:hget(hash, username)
-	if not stored then
-		return false
-	else
-		return stored
-	end
-end
+-- Resolves username. Returns ID of user if it was early stored in date base.
+-- Argument username must begin with symbol @ (commercial 'at')
+function misc.resolve_user(username)
+	assert(username:byte(1) == string.byte('@'))
 
-function misc.res_user_group(username, chat_id)
-	if not username then return false end
-	username = username:lower()
-	local hash = 'bot:usernames:'..chat_id
-	local stored = db:hget(hash, username)
-	if stored then
-		return stored
-	else
-		hash = 'bot:usernames'
-		stored = db:hget(hash, username)
-		if stored then
-			return stored
-		else
-			return false
-		end
-	end
-end
+	local stored_id = db:hget('bot:usernames', username:lower())
+	if not stored_id then return false end
+	local user_obj = api.getChat(stored_id)
+	if not user_obj then return stored_id end
 
-function misc.is_lang_supported(code)
-	return config.available_languages[code:lower()] ~= nil
+	-- User could change his username. Update it
+	db:hset('bot:usernames', username:lower(), user_obj.result.id)
+	return user_obj.result.id
 end
 
 function misc.write_file(path, text, mode)
@@ -742,7 +725,7 @@ function misc.get_user_id(msg, blocks)
 			return msg.reply.from.id
 		elseif msg.text:match(config.cmd..'%w%w%w%w?%w?%w?%s(@[%w_]+)%s?') then
 			local username = msg.text:match('%s(@[%w_]+)')
-			local id = misc.res_user_group(username, msg.chat.id)
+			local id = misc.resolve_user(username)
 			if not id then
 				return false, "I've never seen this user before.\n"
 					.. "If you want to teach me who is he, forward me a message from him"


### PR DESCRIPTION
I couldn't kick an another bot via command /kick because Group Butler didn't see his messages and had no an information about another bots before. Now Group Butler can remove the another bot via command /kick with the mention if he was added into a group after Group Butler.

As you can see on this screenshot, the test bot can kick @bold

[![](http://i.imgur.com/Q12rtl5.png)](http://imgur.com/Q12rtl5)