### PR TITLE
Add some aliases for /settings and /report

### DIFF
--- a/plugins/configure.lua
+++ b/plugins/configure.lua
@@ -35,6 +35,7 @@ return {
     action = action,
     triggers = {
         config.cmd..'config$',
+        config.cmd..'settings$',
         '^###cb:config:back:'
     }
 }

--- a/plugins/private_settings.lua
+++ b/plugins/private_settings.lua
@@ -44,7 +44,7 @@ local function action(msg, blocks)
     end
     if msg.cb then
         if blocks[1] == 'alert' then
-            api.answerCallbackQuery(msg.cb_id, 'Tap on the icons', true)
+            api.answerCallbackQuery(msg.cb_id, _("Tap on the icons"), true)
         else
             change_private_setting(msg.from.id, blocks[1])
             local keyboard = doKeyboard_privsett(msg.from.id)
@@ -57,7 +57,8 @@ end
 return {
     action = action,
     triggers = {
-        '^/(mysettings)$',
+        config.cmd..'(mysettings)$',
+        config.cmd..'(settings)$',
         '^###cb:myset:(.*)$'
     }
 }

--- a/plugins/report.lua
+++ b/plugins/report.lua
@@ -47,6 +47,7 @@ end
 return {
     action = action,
     triggers = {
-        '^@admin'
+        '^@admin',
+        config.cmd..'(report)$',
     }
 }


### PR DESCRIPTION
I suggest these aliases for @admin and /mysetting commands. I think it will be useful for sameness. Also if you specify /settings in the list of commands in PM of @botFather, Telegram clients will be able to show "Settings" point in menu.