### PR TITLE
Persistent connection and some improvements

### DIFF
--- a/bot.lua
+++ b/bot.lua
@@ -1,5 +1,4 @@
-HTTP = require('socket.http')
-HTTPS = require('ssl.https')
+curl = require('cURL')
 URL = require('socket.url')
 JSON = require('dkjson')
 redis = require('redis')
@@ -86,20 +85,20 @@ local function extract_usernames(msg)
 	if msg.forward_from and msg.forward_from.username then
 		db:hset('bot:usernames', '@'..msg.forward_from.username:lower(), msg.forward_from.id)
 	end
-	if msg.added then
-		if msg.added.username then
-			db:hset('bot:usernames', '@'..msg.added.username:lower(), msg.added.id)
+	if msg.new_chat_member then
+		if msg.new_chat_member.username then
+			db:hset('bot:usernames', '@'..msg.new_chat_member.username:lower(), msg.new_chat_member.id)
 		end
-		db:sadd(string.format('chat:%d:members', msg.chat.id), msg.added.id)
+		db:sadd(string.format('chat:%d:members', msg.chat.id), msg.new_chat_member.id)
 	end
-	if msg.removed then
-		if msg.removed.username then
-			db:hset('bot:usernames', '@'..msg.removed.username:lower(), msg.removed.id)
+	if msg.left_chat_member then
+		if msg.left_chat_member.username then
+			db:hset('bot:usernames', '@'..msg.left_chat_member.username:lower(), msg.left_chat_member.id)
 		end
-		db:srem(string.format('chat:%d:members', msg.chat.id), msg.removed.id)
+		db:srem(string.format('chat:%d:members', msg.chat.id), msg.left_chat_member.id)
 	end
-	if msg.reply then
-		extract_usernames(msg.reply)
+	if msg.reply_to_message then
+		extract_usernames(msg.reply_to_message)
 	end
 	if msg.pinned_message then
 		extract_usernames(msg.pinned_message)

--- a/config.lua
+++ b/config.lua
@@ -16,7 +16,8 @@ return {
 		notify_bug = true,
 		log_api_errors = true,
 		stream_commands = true,
-		admin_mode = false
+		admin_mode = false,
+		debug_connections = true,
 	},
 	channel = '@groupbutler_ch', --channel username with the '@'
 	source_code = 'https://github.com/RememberTheAir/GroupButler',
@@ -72,17 +73,6 @@ return {
 		-- more to come
 	},
 	allow_fuzzy_translations = false,
-	media_list = {
-		'image',
-		'audio',
-		'video',
-		'sticker',
-		'gif',
-		'voice',
-		'contact',
-		'file',
-		'link'
-	},
 	chat_settings = {
 		['settings'] = {
 			['Welcome'] = 'on',

--- a/methods.lua
+++ b/methods.lua
@@ -37,7 +37,10 @@ local function sendRequest(url)
 	if code ~= 200 then
 		print(clr.red..code, tab.description..clr.reset)
 		
-		if code == 400 then code = api.getCode(tab.description) end --error code 400 is general: try to specify
+		if code == 400 then
+			 --error code 400 is general: try to specify
+			 code = getCode(tab.description)
+		end
 		db:hincrby('bot:errors', code, 1)
 		
 		return false, code, tab.description
@@ -71,15 +74,6 @@ function api.getUpdates(offset)
 
 end
 
-function api.getCode(error)
-	for k,v in pairs(config.api_errors) do
-		if error:match(v) then
-			return k
-		end
-	end
-	return 7 --if unknown
-end
-
 function api.unbanChatMember(chat_id, user_id)
 	
 	local url = BASE_URL .. '/unbanChatMember?chat_id=' .. chat_id .. '&user_id=' .. user_id
@@ -107,7 +101,7 @@ local function code2text(code)
 		return _("I can't kick or ban an admin")
 	elseif code == 103 then
 		return _("There is no need to unban in a normal group")
-	elseif code == 106 then
+	elseif code == 106 or code == 134 then
 		return _("This user is not a chat member")
 	elseif code == 7 then
 		return false

--- a/plugins/dashboard.lua
+++ b/plugins/dashboard.lua
@@ -81,6 +81,22 @@ local action = function(msg, blocks)
     if msg.cb then
         local request = blocks[2]
         local text, notification
+
+		local res = api.getChat(chat_id)
+		if not res then
+			api.answerCallbackQuery(msg.cb_id, _("🚫 This group was deleted"))
+			return
+		end
+		-- Private chats have no an username
+		local private = not res.result.username
+
+		local res = api.getChatMember(chat_id, msg.from.id)
+		if not res or (res.result.status == 'left' or res.result.status == 'kicked') and private then
+			api.editMessageText(msg.from.id, msg.message_id, _("🚷 You aren't member chat. " ..
+				"You can't watch settings of the private group."))
+			return
+		end
+
         keyboard = doKeyboard_dashboard(chat_id)
         if request == 'settings' then
             text = misc.getSettings(chat_id)
@@ -94,7 +110,7 @@ local action = function(msg, blocks)
             local creator, admins = misc.getAdminlist(chat_id)
             if not creator then
                 -- creator is false, admins is the error code
-                text = _("I'm not an admin in this group.\n*Only an admin can see a list of admins.*")
+                text = _("I got kicked out of this group 😓")
             else
                 text = _("*Creator*:\n%s\n\n*Admins*:\n%s"):format(creator, admins)
             end
@@ -121,7 +137,7 @@ local action = function(msg, blocks)
             end
             notification = _("ℹ️ Group ► Media")
         end
-        api.editMessageText(msg.chat.id, msg.message_id, text, keyboard, true)
+        api.editMessageText(msg.from.id, msg.message_id, text, keyboard, true)
         api.answerCallbackQuery(msg.cb_id, notification)
         return
     end

--- a/plugins/floodmanager.lua
+++ b/plugins/floodmanager.lua
@@ -91,7 +91,12 @@ local function changeFloodSettings(chat_id, screm)
 end
 
 local function action(msg, blocks)
-    if not msg.cb and msg.chat.type == 'private' then return end
+	if not msg.cb then return end
+	local chat_id = msg.target_id or msg.chat.id
+	if not roles.is_admin_cached(chat_id, msg.from.id) then
+		api.answerCallbackQuery(msg.cb_id, _("You're no longer admin"))
+		return
+	end
 
 	local header = _([[
 You can manage the group flood settings from here.
@@ -112,7 +117,6 @@ You can set some exceptions for the antiflood:
 • *Note*: in "_texts_" are included all the other types of media (file, audio...)
 ]])
 
-    local chat_id = msg.target_id or msg.chat.id
     local text
     
     if blocks[1] == 'config' then

--- a/plugins/floodmanager.lua
+++ b/plugins/floodmanager.lua
@@ -58,7 +58,7 @@ local function do_keyboard_flood(chat_id)
     return keyboard
 end
 
-function changeFloodSettings(chat_id, screm)
+local function changeFloodSettings(chat_id, screm)
     local hash = 'chat:'..chat_id..':flood'
     if type(screm) == 'string' then
         if screm == 'kick' then

--- a/plugins/mediasettings.lua
+++ b/plugins/mediasettings.lua
@@ -55,15 +55,20 @@ local function doKeyboard_media(chat_id)
     return keyboard
 end
 
-local action = function(msg, blocks)
+local function action(msg, blocks)
+	if not msg.cb then return end
+	local chat_id = msg.target_id or msg.chat.id
+	if not roles.is_admin_cached(chat_id, msg.from.id) then
+		api.answerCallbackQuery(msg.cb_id, _("You're no longer admin"))
+		return
+	end
+
 	local media_first = _([[
 Tap on a voice in the right colon to *change the setting*
 You can use the last line to change how many warnings should the bot give before kick / ban someone for a forbidden media
 The number is not related the the normal `/warn` command
 ]])
 
-	local chat_id = msg.target_id
-	
 	if  blocks[1] == 'config' then
 		local keyboard = doKeyboard_media(chat_id)
 	    api.editMessageText(msg.chat.id, msg.message_id, media_first, keyboard, true)
@@ -115,11 +120,11 @@ end
 return {
 	action = action,
 	triggers = {
-		'^###cb:(media):(%a+):(-%d+)',
-		'^###cb:(mediatype):(-%d+)',
-		'^###cb:(mediawarn):(%a+):(-%d+)',
+		'^###cb:(media):(%a+):(-?%d+)',
+		'^###cb:(mediatype):(-?%d+)',
+		'^###cb:(mediawarn):(%a+):(-?%d+)',
 		'^###cb:(mediallert)',
 		
-		'^###cb:(config):media:(-%d+)$'
+		'^###cb:(config):media:(-?%d+)$'
 	}
 }

--- a/plugins/menu.lua
+++ b/plugins/menu.lua
@@ -163,7 +163,14 @@ local function doKeyboard_menu(chat_id)
     return keyboard
 end
 
-local action = function(msg, blocks)
+local function action(msg, blocks)
+	if not msg.cb then return end
+	local chat_id = msg.target_id or msg.chat.id
+	if not roles.is_admin_cached(chat_id, msg.from.id) then
+		api.answerCallbackQuery(msg.cb_id, _("You're no longer admin"))
+		return
+	end
+
 	local menu_first = _([[
 Manage the settings of the group.
 📘 _Short legenda_:
@@ -222,6 +229,6 @@ return {
     	
     	'^###cb:(menu):(.*):',
     	
-    	'^###cb:(config):menu:(-%d+)$'
+    	'^###cb:(config):menu:(-?%d+)$'
 	}
 }

--- a/plugins/rules.lua
+++ b/plugins/rules.lua
@@ -11,6 +11,21 @@ local action = function(msg, blocks)
     if msg.chat.type == 'private' then
     	if blocks[1] == 'start' then
     		msg.chat.id = tonumber(blocks[2])
+
+			local res = api.getChat(msg.chat.id)
+			if not res then
+				api.sendMessage(msg.from.id, _("🚫 Unknown or already non-existent group"))
+				return
+			end
+			-- Private chats have no an username
+			local private = not res.result.username
+
+			local res = api.getChatMember(msg.chat.id, msg.from.id)
+			if not res or (res.result.status == 'left' or res.result.status == 'kicked') and private then
+				api.sendMessage(msg.from.id, _("🚷 You aren't member chat. " ..
+					"You can't watch rules of the private group."))
+				return
+			end
     	else
     		return
     	end
@@ -67,6 +82,6 @@ return {
 		config.cmd..'(setrules)$',
 		config.cmd..'(setrules) (.*)',
 		config.cmd..'(rules)$',
-		'^/(start) (-%d+):rules$'
+		'^/(start) (-?%d+):rules$'
 	}
 }

--- a/plugins/users.lua
+++ b/plugins/users.lua
@@ -202,7 +202,7 @@ local action = function(msg, blocks)
 		
 		local user_id = msg.target_id
 		
-		local res, text = api.banUser(msg.chat.id, user_id, msg.normal_group)
+		local res, text = api.banUser(msg.chat.id, user_id)
 		if res then
 			misc.saveBan(user_id, 'ban')
 			local name = misc.getname_link(msg.from.first_name, msg.from.username) or msg.from.first_name:escape()

--- a/utilities.lua
+++ b/utilities.lua
@@ -209,13 +209,22 @@ end
 function misc.resolve_user(username)
 	assert(username:byte(1) == string.byte('@'))
 
-	local stored_id = db:hget('bot:usernames', username:lower())
+	local stored_id = tonumber(db:hget('bot:usernames', username:lower()))
 	if not stored_id then return false end
 	local user_obj = api.getChat(stored_id)
 	if not user_obj then return stored_id end
 
-	-- User could change his username. Update it
-	db:hset('bot:usernames', username:lower(), user_obj.result.id)
+	-- User could change his username
+	if username ~= '@' .. user_obj.result.username then
+		if user_obj.result.username then
+			-- Update it if it exists
+			db:hset('bot:usernames', user_obj.result.username:lower(), user_obj.result.id)
+		end
+		-- And return false because this user not the same that asked
+		return false
+	end
+
+	assert(stored_id == user_obj.result.id)
 	return user_obj.result.id
 end
 

--- a/utilities.lua
+++ b/utilities.lua
@@ -67,12 +67,20 @@ function roles.is_admin(msg)
 	end
 end
 
-function roles.is_admin_cached(msg)
-	local hash = 'cache:chat:'..msg.chat.id..':admins'
-	if not db:exists(hash) then
-		misc.cache_adminlist(msg.chat.id, res)
+-- Returns the admin status of the user. The first argument can be the message,
+-- then the function checks the rights of the sender in the incoming chat.
+function roles.is_admin_cached(chat_id, user_id)
+	if type(chat_id) == 'table' then
+		local msg = chat_id
+		chat_id = msg.chat.id
+		user_id = msg.from.id
 	end
-	return db:sismember(hash, msg.from.id)
+
+	local hash = 'cache:chat:'..chat_id..':admins'
+	if not db:exists(hash) then
+		misc.cache_adminlist(chat_id, res)
+	end
+	return db:sismember(hash, user_id)
 end
 
 function roles.is_admin2(chat_id, user_id)


### PR DESCRIPTION
I implemented persistent connection with [api.telegram.org](https://api.telegram.org) (learn more in [Wikipedia](https://en.wikipedia.org/wiki/HTTP_persistent_connection)). So now the bot responds much faster. Also I made few additional improvements such as repairing statistics, fixing bug during attempt ban non-member. Now non-members can watch rules and dashboard of public groups only, and old admins can't change settings of the bot.

I used [Lua-cURL](https://github.com/Lua-cURL/Lua-cURLv3) library. It needs to be installed. I leaved a debug output of *cURL*. To disable it, set `config.bot_settings.debug_connections` flag to _false_.

I have made a single pull request, but I can split it into separate parts, if you wish.