### PR TITLE
Goodbye message, improve escaping text, ignoring forward by antiflood

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -75,6 +75,7 @@ return {
 	chat_settings = { --default chat_settings for groups.
 		['settings'] = {
 			['Welcome'] = 'on',
+			['Goodbye'] = 'on',
 			['Extra'] = 'on',
 			['Flood'] = 'off',
 			['Silent'] = 'off',
@@ -106,6 +107,9 @@ return {
 		['welcome'] = {
 			['type'] = 'no',
 			['content'] = 'no'
+		},
+		['goodbye'] = {
+			['type'] = 'custom',
 		},
 		['media'] = {
 			['photo'] = 'ok', --'notok' | image

--- a/plugins/dashboard.lua
+++ b/plugins/dashboard.lua
@@ -1,20 +1,5 @@
 local plugin = {}
 
-local media_texts = {
-	photo = _("Images"),
-	gif = _("GIFs"),
-	video = _("Videos"),
-	document = _("Documents"),
-	TGlink = _("telegram.me links"),
-	voice = _("Vocal messages"),
-	link = _("Links"),
-	audio = _("Music"),
-	sticker = _("Stickers"),
-	contact = _("Contacts"),
-	game = _("Games"),
-	location = _("Locations")
-}
-
 local function getFloodSettings_text(chat_id)
     local status = db:hget('chat:'..chat_id..':settings', 'Flood') or 'yes' --check (default: disabled)
     if status == 'no' then
@@ -32,6 +17,7 @@ local function getFloodSettings_text(chat_id)
     local num = (db:hget(hash, 'MaxFlood')) or 5
     local exceptions = {
         text = _("Texts"),
+		forward = _("Forward"),
         sticker = _("Stickers"),
         image = _("Images"),
         gif = _("GIFs"),
@@ -135,6 +121,20 @@ function plugin.onCallbackQuery(msg, blocks)
         notification = _("ℹ️ Group ► Flood")
     end
     if request == 'media' then
+		local media_texts = {
+			photo = _("Images"),
+			gif = _("GIFs"),
+			video = _("Videos"),
+			document = _("Documents"),
+			TGlink = _("telegram.me links"),
+			voice = _("Vocal messages"),
+			link = _("Links"),
+			audio = _("Music"),
+			sticker = _("Stickers"),
+			contact = _("Contacts"),
+			game = _("Games"),
+			location = _("Locations"),
+		}
         text = _("*Current media settings*:\n\n")
         for media, default_status in pairs(config.chat_settings['media']) do
             local status = (db:hget('chat:'..chat_id..':media', media)) or default_status

--- a/plugins/extra.lua
+++ b/plugins/extra.lua
@@ -57,14 +57,14 @@ function plugin.onTextMessage(msg, blocks)
 	    
 	    local hash = 'chat:'..msg.chat.id..':extra'
 	    local commands = db:hkeys(hash)
-	    local text = ''
-	    if commands[1] == nil then
+	    if not next(commands) then
 	        api.sendReply(msg, _("No commands set"))
 	    else
-	        for k,v in pairs(commands) do
-	            text = text..v..'\n'
+			local lines = {}
+	        for k, v in pairs(commands) do
+				table.insert(lines, (v:gsub('_', '\\_')))
 	        end
-	        local out = _("List of *custom commands*:\n") .. text
+	        local out = _("List of *custom commands*:\n") .. table.concat(lines, '\n')
 	        api.sendReply(msg, out, true)
 	    end
     elseif blocks[1] == 'extra del' then

--- a/plugins/floodmanager.lua
+++ b/plugins/floodmanager.lua
@@ -33,6 +33,7 @@ local function do_keyboard_flood(chat_id)
     
     local exceptions = {
         text = _("Texts"),
+		forward = _("Forward"),
         sticker = _("Stickers"),
         photo = _("Images"),
         gif = _("GIFs"),

--- a/plugins/floodmanager.lua
+++ b/plugins/floodmanager.lua
@@ -163,7 +163,7 @@ You can set some exceptions for the antiflood:
         
         if blocks[1] == 'status' then
             local status = db:hget('chat:'..chat_id..':settings', 'Flood') or config.chat_settings['settings']['Flood']
-            text = misc.changeSettingStatus(chat_id, 'Flood'):escape_hard()
+            text = misc.changeSettingStatus(chat_id, 'Flood')
         end
         
         local keyboard = do_keyboard_flood(chat_id)

--- a/plugins/help.lua
+++ b/plugins/help.lua
@@ -94,6 +94,11 @@ Placeholders:
 
 *GIF/sticker as welcome message*
 You can use a particular gif/sticker as welcome message. To set it, reply to the gif/sticker you want to set as welcome message with `/welcome`
+
+*Goodbye message*
+Also you can set the custom goodbye message:
+`/goodbye` _message_
+Same placeholders and media are available
 ]])
 	elseif key == 'mods_extra' then
 		return _([[

--- a/plugins/help.lua
+++ b/plugins/help.lua
@@ -79,26 +79,27 @@ _Note_ : the number must be higher than 3 and lower than 26.
 		return _([[
 *Admins: welcome settings*
 
-`/config`, then `menu` tab = receive in private the menu keyboard. You will find an option to enable/disable welcome and goodbye messages.
+The bot can salute new members and say goodbye to left. You will find an option for enable / disable these features in the group menu. To get it in PM, send `/config` command to the group and tap on "Menu" button.
 
 *Custom welcome message*:
-`/welcome Welcome $name, enjoy the group!`
-Write after `/welcome` your welcome message. You can use some placeholders to include the name/username/id of the new member of the group
-Placeholders:
-`$username`: _will be replaced with the username_
+Example: `/welcome Welcome $name, enjoy the group!`
+Write after `/welcome` your welcome message. You can use some placeholders to include the name / username / id of the new member of the group. At the moment placeholders inside markdown markup isn't supported.
+
+*Placeholders*:
 `$name`: _will be replaced with the name_
+`$surname`: _will be replaced by the user's last name_
+`$username`: _will be replaced with the username_
 `$id`: _will be replaced with the id_
 `$title`: _will be replaced with the group title_
-`$surname`: _will be replaced by the user's last name_
 `$rules`: _will be replaced by a link to the rules of the group. Please read_ [here](https://telegram.me/GroupButler_beta/26) _how to use it, or you will get an error for sure_
 
-*GIF/sticker as welcome message*
-You can use a particular gif/sticker as welcome message. To set it, reply to the gif/sticker you want to set as welcome message with `/welcome`
+*GIF / sticker as welcome message*
+You can use a particular gif/sticker as welcome message. To set it, reply to the gif / sticker which you want to set as welcome message with `/welcome`.
 
 *Goodbye message*
 Also you can set the custom goodbye message:
 `/goodbye` _message_
-Same placeholders and media are available
+Same placeholders and media are available.
 ]])
 	elseif key == 'mods_extra' then
 		return _([[

--- a/plugins/links.lua
+++ b/plugins/links.lua
@@ -16,7 +16,7 @@ function plugin.onTextMessage(msg, blocks)
 		if not link then
 			text = _("*No link* for this group. Ask the owner to generate one")
 		else
-			local title = msg.chat.title:escape_hard()
+			local title = msg.chat.title:escape_hard('link')
 			text = string.format('[%s](%s)', title, link)
 		end
 		api.sendReply(msg, text, true)
@@ -48,7 +48,7 @@ function plugin.onTextMessage(msg, blocks)
 			text = _("Link *unsetted*")
 		else
 			local succ = db:hset(hash, key, link)
-			local title = msg.chat.title:escape_hard()
+			local title = msg.chat.title:escape_hard('link')
 			local substitution = '['..title..']('..link..')'
 			if succ == false then
 				text = _("The link has been updated.\n*Here's the new link*: %s"):format(substitution)

--- a/plugins/menu.lua
+++ b/plugins/menu.lua
@@ -110,7 +110,8 @@ end
 
 local function insert_settings_section(keyboard, settings_section, chat_id)
 	local strings = {
-		Welcome = _("Welcome message"),
+		Welcome = _("Welcome"),
+		Goodbye = _("Goodbye"),
 		Extra = _("Extra"),
 		Flood = _("Anti-flood"),
 		Silent = _("Silent mode"),

--- a/plugins/onmessage.lua
+++ b/plugins/onmessage.lua
@@ -51,8 +51,8 @@ function plugin.onEveryMessage(msg)
     if not msg.inline then
     
     local msg_type = 'text'
-    if msg.media then msg_type = msg.media_type end
-    if not is_ignored(msg.chat.id, msg_type) then
+	if msg.forward_from or msg.forward_from_chat then msg_type = 'forward' end
+	if not is_ignored(msg.chat.id, msg_type) or msg.media and not is_ignored(msg.chat.id, msg.media_type) then
         local is_flooding, msgs_sent, msgs_max = is_flooding_funct(msg)
         if is_flooding then
             local status = (db:hget('chat:'..msg.chat.id..':settings', 'Flood')) or config.chat_settings['settings']['Flood']
@@ -144,6 +144,7 @@ function plugin.onEveryMessage(msg)
 					message = _("%s *banned*: RTL character in names / messages not allowed!"):format(name)
     	        end
     	        api.sendMessage(msg.chat.id, message, true)
+				return false -- not execute command already kicked out and not welcome him
     	    end
         end
     end
@@ -166,6 +167,7 @@ function plugin.onEveryMessage(msg)
 						message = _("%s *banned*: arab message detected!"):format(name)
     	            end
     	            api.sendMessage(msg.chat.id, message, true)
+					return false
     	        end
             end
         end

--- a/plugins/pin.lua
+++ b/plugins/pin.lua
@@ -15,7 +15,7 @@ function plugin.onTextMessage(msg, blocks)
 		local pin_id = db:get('chat:'..msg.chat.id..':pin')
 		local was_deleted
 		if pin_id then --try to edit the old message
-			local res, code = api.editMessageText(msg.chat.id, pin_id, blocks[2]:replaceholders_dyn(msg, '$rules', '$title'), true)
+			local res, code = api.editMessageText(msg.chat.id, pin_id, blocks[2]:replaceholders(msg, 'rules', 'title'), true)
 			if not res then
 				if code == 118 then
 			    	api.sendMessage(msg.chat.id, _("This text is too long, I can't send it"))
@@ -36,7 +36,7 @@ function plugin.onTextMessage(msg, blocks)
 	    	end
 		end
 		if not pin_id then
-			local res, code = api.sendMessage(msg.chat.id, blocks[2]:replaceholders_dyn(msg, '$rules', '$title'), true)
+			local res, code = api.sendMessage(msg.chat.id, blocks[2]:replaceholders(msg, 'rules', 'title'), true)
 			if not res then
 				if code == 118 then
 					api.sendReply(msg, _("This text is too long, I can't send it"))

--- a/plugins/service.lua
+++ b/plugins/service.lua
@@ -27,22 +27,12 @@ function plugin.onTextMessage(msg, blocks)
 	if blocks[1] == 'left_chat_member:bot' then
 		misc.remGroup(msg.chat.id, nil, 'bot removed')
 	end
-	if blocks[1] == 'left_chat_member' then
-		if msg.from and msg.left_chat_member then
-			if msg.from.id ~= msg.left_chat_member.id and msg.from.id ~= bot.id then
-				if msg.chat.type == 'supergroup' then
-					misc.saveBan(msg.left_chat_member.id, 'ban')
-				end
-			end
-		end
-	end
 end
 
 plugin.triggers = {
 	onTextMessage = {
 		'^###(new_chat_member:bot)',
 		'^###(left_chat_member:bot)',
-		'^###(left_chat_member)$'
 	}
 }
 

--- a/plugins/welcome.lua
+++ b/plugins/welcome.lua
@@ -23,29 +23,29 @@ local function get_welcome(msg)
 	elseif type == 'custom' then
 		return content:replaceholders(msg)
 	else
-		return _("Hi %s, and welcome to *%s*!"):format(msg.new_chat_member.first_name:escape_hard(), msg.chat.title:escape_hard())
+		return _("Hi %s, and welcome to *%s*!"):format(msg.new_chat_member.first_name:escape(), msg.chat.title:escape_hard('bold'))
 	end
 end
 
 local function get_goodbye(msg)
 	if is_locked(msg.chat.id, 'Goodbye') then
-		 return false
+		return false
 	end
 	local type = db:hget('chat:'..msg.chat.id..':goodbye', 'type') or 'custom'
 	local content = db:hget('chat:'..msg.chat.id..':goodbye', 'content')
 	if type == 'media' then
-		 local file_id = content
-		 api.sendDocumentId(msg.chat.id, file_id)
-		 return false
+		local file_id = content
+		api.sendDocumentId(msg.chat.id, file_id)
+		return false
 	elseif type == 'custom' then
-		 if not content then
-				 local name = msg.left_chat_member.first_name
-				 if msg.left_chat_member.username then
-						 name = name..' (@'..msg.left_chat_member.username..')'
-				 end
-				 return _("Goodbye, %s!"):format(name:escape_hard())
-		 end
-		 return content:replaceholders(msg)
+		if not content then
+			local name = msg.left_chat_member.first_name
+			if msg.left_chat_member.username then
+				name = name:escape() .. ' (@' .. msg.left_chat_member.username:escape() .. ')'
+			end
+			return _("Goodbye, %s!"):format(name)
+		end
+		return content:replaceholders(msg)
 	end
 end
 

--- a/plugins/welcome.lua
+++ b/plugins/welcome.lua
@@ -1,8 +1,8 @@
 local plugin = {}
 
-local function is_locked(chat_id)
+local function is_locked(chat_id, thing)
   	local hash = 'chat:'..chat_id..':settings'
-  	local current = db:hget(hash, 'Welcome')
+  	local current = db:hget(hash, thing)
   	if current == 'off' then
   		return true
   	else
@@ -11,7 +11,7 @@ local function is_locked(chat_id)
 end
 
 local function get_welcome(msg)
-	if is_locked(msg.chat.id) then
+	if is_locked(msg.chat.id, 'Welcome') then
 		return false
 	end
 	local type = (db:hget('chat:'..msg.chat.id..':welcome', 'type')) or config.chat_settings['welcome']['type']
@@ -24,6 +24,28 @@ local function get_welcome(msg)
 		return content:replaceholders(msg)
 	else
 		return _("Hi %s, and welcome to *%s*!"):format(msg.new_chat_member.first_name:escape_hard(), msg.chat.title:escape_hard())
+	end
+end
+
+local function get_goodbye(msg)
+	if is_locked(msg.chat.id, 'Goodbye') then
+		 return false
+	end
+	local type = db:hget('chat:'..msg.chat.id..':goodbye', 'type') or 'custom'
+	local content = db:hget('chat:'..msg.chat.id..':goodbye', 'content')
+	if type == 'media' then
+		 local file_id = content
+		 api.sendDocumentId(msg.chat.id, file_id)
+		 return false
+	elseif type == 'custom' then
+		 if not content then
+				 local name = msg.left_chat_member.first_name
+				 if msg.left_chat_member.username then
+						 name = name..' (@'..msg.left_chat_member.username..')'
+				 end
+				 return _("Goodbye, %s!"):format(name:escape_hard())
+		 end
+		 return content:replaceholders(msg)
 	end
 end
 
@@ -75,6 +97,55 @@ function plugin.onTextMessage(msg, blocks)
             end
         end
     end
+	if blocks[1] == 'goodbye' then
+		if msg.chat.type == 'private' or not roles.is_admin_cached(msg) then return end
+
+		local input = blocks[2]
+		local hash = 'chat:'..msg.chat.id..':goodbye'
+
+		-- ignore if not input text and not reply
+		if not input and not msg.reply then
+			api.sendReply(msg, _("No goodbye message"), false)
+			return
+		end
+
+		if not input and msg.reply then
+			local replied_to = misc.get_media_type(msg.reply)
+			if replied_to == 'sticker' or replied_to == 'gif' then
+				local file_id
+				if replied_to == 'sticker' then
+					file_id = msg.reply.sticker.file_id
+				else
+					file_id = msg.reply.document.file_id
+				end
+				db:hset(hash, 'type', 'media')
+				db:hset(hash, 'content', file_id)
+				api.sendReply(msg, _("New media setted as goodbye message: `%s`"):format(replied_to), true)
+			else
+				api.sendReply(msg, _("Reply to a `sticker` or a `gif` to set them as *goodbye message*"), true)
+			end
+			return
+		end
+
+		input = input:gsub('^%s*(.-)%s*$', '%1') -- trim spaces
+		db:hset(hash, 'type', 'custom')
+		db:hset(hash, 'content', input)
+		local res, code = api.sendReply(msg, _("*Custom goodbye message* setted!\n\n%s"):format(input), true)
+		if not res then
+			db:hset(hash, 'type', 'composed') --if wrong markdown, remove 'custom' again
+			db:hset(hash, 'content', 'no')
+			if code == 118 then
+				api.sendMessage(msg.chat.id, _("This text is too long, I can't send it"))
+			else
+				api.sendMessage(msg.chat.id, _("This text breaks the markdown.\n"
+						.. "More info about a proper use of markdown "
+						.. "[here](https://telegram.me/GroupButler_ch/46)."), true)
+			end
+		else
+			local id = res.result.message_id
+			api.editMessageText(msg.chat.id, id, _("*Custom goodbye message saved!*"), true)
+		end
+	end
     if blocks[1] == 'new_chat_member' then
 		if not msg.service then return end
 		
@@ -103,13 +174,30 @@ function plugin.onTextMessage(msg, blocks)
 		    end
 	    end
 	end
+	if blocks[1] == 'left_chat_member' then
+		if not msg.service then return end
+
+		if msg.left_chat_member.username and msg.left_chat_member.username:lower():find('bot', -3) then return end
+		local text = get_goodbye(msg)
+		if text then
+			api.sendMessage(msg.chat.id, text, true)
+		end
+	end
 end
 
 plugin.triggers = {
 	onTextMessage = {
 		config.cmd..'(welcome) (.*)$',
+		config.cmd..'set(welcome) (.*)$',
 		config.cmd..'(welcome)$',
-		'^###(new_chat_member)$'
+		config.cmd..'set(welcome)$',
+		config.cmd..'(goodbye) (.*)$',
+		config.cmd..'set(goodbye) (.*)$',
+		config.cmd..'(goodbye)$',
+		config.cmd..'set(goodbye)$',
+
+		'^###(new_chat_member)$',
+		'^###(left_chat_member)$',
 	}
 }
 

--- a/plugins/welcome.lua
+++ b/plugins/welcome.lua
@@ -39,7 +39,7 @@ local function get_goodbye(msg)
 		return false
 	elseif type == 'custom' then
 		if not content then
-			local name = msg.left_chat_member.first_name
+			local name = msg.left_chat_member.first_name:escape()
 			if msg.left_chat_member.username then
 				name = name:escape() .. ' (@' .. msg.left_chat_member.username:escape() .. ')'
 			end

--- a/utilities.lua
+++ b/utilities.lua
@@ -25,31 +25,14 @@ function string:input() -- Returns the string after the first space.
 	return self:sub(self:find(' ')+1)
 end
 
--- Escape markdown for Telegram. I don't know how escape asterisks (*) inside
--- bold font, underlines (_) inside italic font, accents (`) inside fixed-width
--- code and closing square brackets (]) inside link text. A backslash (\)
--- should be escaped, if only it precedes a special character. Also this
--- function makes non-clickable usernames, hashtags, commands and links, if
--- only_markup flag isn't setted.
+-- Escape markdown for Telegram. This function makes non-clickable usernames,
+-- hashtags, commands, links and emails, if only_markup flag isn't setted.
 function string:escape(only_markup)
 	if not only_markup then
 		-- insert word joiner
-		self = self:gsub('[@#/]', {
-			['@'] = '@⁠',  -- avoid usernames and emails
-			['#'] = '#⁠',  -- avoid hashtags
-			['/'] = '/⁠',  -- avoid bot commands
-		}):gsub('%.(%w)', '⁠.%1')  -- avoid links
+		self = self:gsub('([@#/.])(%w)', '%1⁠%2')
 	end
-	return self:gsub('\\?[*_`[]', {
-		['*'] = '\\*',
-		['_'] = '\\_',
-		['`'] = '\\`',
-		['['] = '\\[',
-		['\\*'] = '\\\\*',
-		['\\_'] = '\\\\_',
-		['\\`'] = '\\\\`',
-		['\\['] = '\\\\[',
-	})
+	return self:gsub('[*_`[]', '\\%0')
 end
 
 -- Remove specified formating or all markdown. This function useful for put

--- a/utilities.lua
+++ b/utilities.lua
@@ -47,7 +47,7 @@ function string:escape_hard(ft)
 	elseif ft == 'link' then
 		return self:gsub(']', '')
 	else
-		return self:gsub('\\?[*_`[]', '')
+		return self:gsub('[*_`[%]]', '')
 	end
 end
 
@@ -411,7 +411,7 @@ function string:replaceholders(msg, ...)
 
 	local substitutions = next{...} and {} or replace_map
 	for _, placeholder in pairs{...} do
-		substitutions = replace_map[placeholder]
+		substitutions[placeholder] = replace_map[placeholder]
 	end
 
 	return self:gsub('$(%w+)', substitutions)

--- a/utilities.lua
+++ b/utilities.lua
@@ -198,8 +198,12 @@ function vardump(...)
 	end
 end
 
-function vtext(value)
-  return serpent.block(value, {comment=false})
+function vtext(...)
+	local lines = {}
+	for _, value in pairs{...} do
+		table.insert(lines, serpent.block(value, {comment=false}))
+	end
+	return table.concat(lines, '\n')
 end
 
 function misc.deeplink_constructor(chat_id, what)
@@ -374,6 +378,8 @@ end
 function string:replaceholders(msg) -- Returns the string after the first space.
 	if msg.new_chat_member then
 		msg.from = msg.new_chat_member
+	elseif msg.left_chat_member then
+		msg.from = msg.left_chat_member
 	end
 	
 	msg.from.first_name = msg.from.first_name:gsub('%%', '')
@@ -382,12 +388,12 @@ function string:replaceholders(msg) -- Returns the string after the first space.
 	if msg.from.username then
 		self = self:gsub('$username', '@'..msg.from.username:escape())
 	else
-		self = self:gsub('$username', '@-')
+		self = self:gsub('$username', '-')
 	end
 	if msg.from.last_name then
 		self = self:gsub('$surname', msg.from.last_name:escape())
 	else
-		self = self:gsub('$surname', '-')
+		self = self:gsub('$surname', '')
 	end
 	self = self:gsub('$id', msg.from.id)
 	self = self:gsub('$title', msg.chat.title:escape())
@@ -407,14 +413,14 @@ function string:replaceholders_dyn(msg, ...)
 			if msg.from.username then
 				return '@'..msg.from.username:escape()
 			else
-				return '@-'
+				return '-'
 			end
 		end,
 		['$surname'] = function()
 			if msg.from.last_name then
 				return msg.from.last_name:escape()
 			else
-				return '-'
+				return ''
 			end
 		end,
 		['$id'] = msg.from.id,
@@ -618,6 +624,7 @@ function misc.getSettings(chat_id)
     --build the message
 	local strings = {
 		Welcome = _("Welcome message"),
+		Goodbye = _("Goodbye message"),
 		Extra = _("Extra"),
 		Flood = _("Anti-flood"),
 		Antibot = _("Ban bots"),
@@ -626,6 +633,7 @@ function misc.getSettings(chat_id)
 		Arab = _("Arab"),
 		Rtl = _("RTL"),
 		Reports = _("Reports"),
+		Welbut = _("Welcome button"),
 	}
     for key, default in pairs(config.chat_settings['settings']) do
         
@@ -684,6 +692,7 @@ function misc.changeSettingStatus(chat_id, field)
 	local turned_off = {
 		reports = _("@admin command disabled"),
 		welcome = _("Welcome message won't be displayed from now"),
+		goodbye = _("Goodbye message won't be displayed from now"),
 		extra = _("#extra commands are now available only for moderator"),
 		flood = _("Anti-flood is now off"),
 		rules = _("/rules will reply in private (for users)"),
@@ -693,6 +702,7 @@ function misc.changeSettingStatus(chat_id, field)
 	local turned_on = {
 		reports = _("@admin command enabled"),
 		welcome = _("Welcome message will be displayed"),
+		goodbye = _("Goodbye message will be displayed"),
 		extra = _("#extra commands are now available for all"),
 		flood = _("Anti-flood is now on"),
 		rules = _("/rules will reply in the group (with everyone)"),


### PR DESCRIPTION
As promised, I made goodbye message. It only works in small groups, where the bot sees service messages about left members (the exact number of members is not known to me). Besides I added synonym for /welcome command and rewrote help for /welcome and /goodbye commands.

Also I tried to fix escaping text, but unexpectedly it turned out to be very difficult. Telegram doesn't allow write asterisk inside bold font, underscore inside italic font via Markdown. It seems the only true solution is using HTML for send formatted messages. But I think it will require huge modifications of the bot.

Additionally now anti-flood can ignore forward messages. Used to be very annoyed that normal users could not forward many messages without the risk of being kicked out. Now administrators can set ignoring these messages in the anti-flood menu.

Replaceholders and replaceholders_dyn functions were merged into a single. The italic font in list extra commands was fixed.

This pull request can't be automatically merged, because we simultaneously changed help message. If you wish, I can rebase these commits for automatic merging.