### PR TITLE
Abolish repeated warnings for forbidden media messages when editing

### DIFF
--- a/plugins/onmessage.lua
+++ b/plugins/onmessage.lua
@@ -91,7 +91,7 @@ function plugin.onEveryMessage(msg)
         end
     end
     
-    if msg.media and not(msg.chat.type == 'private') and not msg.cb then
+    if msg.media and msg.chat.type ~= 'private' and not msg.cb and not msg.edited then
         local media = msg.media_type
         local hash = 'chat:'..msg.chat.id..':media'
         local media_status = (db:hget(hash, media)) or 'ok'


### PR DESCRIPTION
I fixed that situation, which was described in the Butler's group.

But one problem with anti-spam still remains: if a violator sends telegram.me link via inline bot, he gets warnings when the bot edits the message. This happens without any user actions.