### PR TITLE
make bot timezone independent

### DIFF
--- a/bot.lua
+++ b/bot.lua
@@ -114,7 +114,9 @@ local function on_msg_receive(msg, callback) -- The fn run whenever a message is
 
 	if msg.chat.type ~= 'group' then --do not process messages from normal groups
 		
-		if msg.date < os.time() - 7 then print('Old update skipped') return end -- Do not process old messages.
+		if msg.date < os.time(os.date("!*t")) - 7 then print('Old update skipped') return end -- Do not process old messages.
+		-- os.time(os.date("!*t")) is used so that the timestamp is returned from UTC, not the current timezone.
+		-- the ! indicates UTC - https://www.lua.org/manual/5.2/manual.html#pdf-os.date
 		if not msg.text then msg.text = msg.caption or '' end
 		
 		locale.language = db:get('lang:'..msg.chat.id) or 'en' --group language


### PR DESCRIPTION
This fixes issues like #163

Using `!` with `os.date` fetches the current time at UTC and os.time is used to convert it to a unix timestamp