### PR TITLE
Move config to environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Group Butler was born as an [otouto](https://otou.to) [v3.1](https://github.com/
 #### Group Butler on Telegram:
 
 - [`@GroupButler_bot`](https://telegram.me/GroupButler_Bot)
-    - **_branch_**: `master`
-    - **_channel_**: [`@GroupButler_ch`](https://telegram.me/groupbutler_ch).
+	- **_branch_**: `master`
+	- **_channel_**: [`@GroupButler_ch`](https://telegram.me/groupbutler_ch).
 
 - [`@GBReborn_bot`](https://telegram.me/GBReborn_bot)
-    - **_branch_**: `beta`
-    - **_channel_**: [`@GroupButler_beta`](https://telegram.me/GroupButler_beta).
+	- **_branch_**: `beta`
+	- **_channel_**: [`@GroupButler_beta`](https://telegram.me/GroupButler_beta).
 
 * * *
 
@@ -82,15 +82,25 @@ Other things to check before running the bot:
 
 > • Make sure privacy is disabled (more info can be found by heading to the [official Bots FAQ page](https://core.telegram.org/bots/faq#what-messages-will-my-bot-get)). Send `/setprivacy` to [@BotFather](http://telegram.me/BotFather) to check the current status of this setting.
 
-**Before you do anything else, open config.lua (in a text editor) and make the following changes:**
+**Before you do anything else, create a plain text file named .env with the following:**
 
-> • Set `bot_api_key` to the authentication token that you received from [`@BotFather`](http://telegram.me/BotFather).
+> * Set `TG_TOKEN` to the authentication token that you received from [`@BotFather`](http://telegram.me/BotFather).
 >
-> • Insert your numerical Telegram ID into the `superadmins` table. Other superadmins can be added too. It is important that you insert the numerical ID and NOT a string.
+> * Set `SUPERADMINS` as a JSON array containing your numerical Telegram ID. Other superadmins can be added too. It is important that you insert the numerical ID and NOT a string.
 >
-> • Set your `log.chat` (the ID of the chat where the bot will send all the bad requests received from Telegram) and your `log.admin` (the ID of the user that will receive execution errors).
+> * Set `LOG_CHAT` (the ID of the chat where the bot will send all the bad requests received from Telegram) and your `LOG_ADMIN` (the ID of the user that will receive execution errors).
+
+Your `.env` file should now look somewhat like this:
+
+```
+TG_TOKEN=123456789:ABCDefGhw3gUmZOq36-D_46_AMwGBsfefbcQ
+SUPERADMINS=[12345678]
+LOG_CHAT=12345678
+LOG_ADMIN=12345678
+```
 
 Before you start the bot, you have to start the Redis process.
+
 ```bash
 # Start Redis
 
@@ -101,25 +111,25 @@ $ sudo service redis-server start
 
 To start the bot, run `./launch.sh`. To stop the bot, press Control <kbd>CTRL</kbd>+<kbd>C</kbd> twice.
 
-You may also start the bot with `lua bot.lua`, however it will not restart automatically.
+You may also start the bot with `./polling.lua`, however it will not restart automatically. You will also need to find another way to export the required environment variables.
 
 * * *
 ## Something that you should known before run the bot
 
-  * You can change some settings of the bot. All the settings are placed in `config.lua`, in the `bot_settings` table
-    * `cache_time.adminlist`: the permanence in seconds of the adminlist in the cache. The bot caches the adminlist to avoid to hit Telegram limits
-    * `notify_bug`: if `true`, the bot will send a message that notifies that a bug has occured to the current user, when a plugin is executed and an error happens
-    * `log_api_errors`: if `true`, the bot will send in the `log_chat` (`config.lua`) all the relevant errors returned by an api request toward Telegram
-    * `stream_commands`: if `true`, when an update triggers a plugin, the match will be printed on the console
-  * There are some other useful fields that can be filled in `config.lua`
-    * `db`: the selected Redis database (if you are running Redis with the default config, the available databases are 16). The database will be selected on each start/reload. Default: 2
-  * Other things that may be useful
-    * Administrators commands start for `$`. They are not documented, look at the triggers of `plugins/admin.lua` plugin for the whole list
-    * If the main function of a plugin returns `true`, the bot will continue to try to match the message text with the missing triggers of the `plugins` table
-    * You can send yourself a backup of the zipped bot folder with the `$backup` command
-    * The Telegram Bot API has some undocumented "weird behaviors" that you may notice while using this bot
-       * In supergroups, the `kickChatMember` method returns always a positive response if the `user_id` has been part of the group at least once, it doesn't matter if the user is not in the group when you use this method
-       * In supergroups, the `unbanChatMember` method returns always a positive response if the `user_id` has been part of the group at least once, it doesn't matter if the user is not in the group or is not in the group blacklist
+* You can change some settings of the bot. All the settings are placed in `config.lua`, in the `bot_settings` table
+	* `cache_time.adminlist`: the permanence in seconds of the adminlist in the cache. The bot caches the adminlist to avoid to hit Telegram limits
+	* `notify_bug`: if `true`, the bot will send a message that notifies that a bug has occurred to the current user, when a plugin is executed and an error happens
+	* `log_api_errors`: if `true`, the bot will send in the `LOG_CHAT` all the relevant errors returned by an api request toward Telegram
+	* `stream_commands`: if `true`, when an update triggers a plugin, the match will be printed on the console
+* There are some other useful fields that can be added to .env you can find in `config.lua`, for instance
+	* `REDIS_DB`: the selected Redis database (if you are running Redis with the default config, the available databases are 16). The database will be selected on each start/reload. Default: 0
+* Other things that may be useful
+	* Administrators commands start for `$`. They are not documented, look at the triggers of `plugins/admin.lua` plugin for the whole list
+	* If the main function of a plugin returns `true`, the bot will continue to try to match the message text with the missing triggers of the `plugins` table
+	* You can send yourself a backup of the zipped bot folder with the `$backup` command
+	* The Telegram Bot API has some undocumented "weird behaviours" that you may notice while using this bot
+		* In supergroups, the `kickChatMember` method returns always a positive response if the `user_id` has been part of the group at least once, it doesn't matter if the user is not in the group when you use this method
+		* In supergroups, the `unbanChatMember` method returns always a positive response if the `user_id` has been part of the group at least once, it doesn't matter if the user is not in the group or is not in the group blacklist
 
 
 ## Some notes about the database
@@ -133,20 +143,11 @@ You can find a backup of your Redis database in `/etc/redis/dump.rdb`. The name 
 ## Translators
 If you want to help translate the bot, follow the instructions below. Parts of Group Butler use tools from [gettext](https://www.gnu.org/software/gettext/). However we don't use binary format `*.mo` for the sake of simplicity. The bot manually parses the `*.po` files in the `locales` directory.
 
-If you want to improve an existing translation, run this command in the root
-directoy with the bot: `./launch.sh update-locale <name>` where &lt;name&gt;
-is two letters of your chosen locale. Further edit the file
-`locales/<name>.po`, make sure that the translation is done correctly and send
-us your translation.
+If you want to improve an existing translation, run this command in the root directoy with the bot: `./launch.sh update-locale <name>` where &lt;name&gt; is two letters of your chosen locale. Further edit the file `locales/<name>.po`, make sure that the translation is done correctly and send your translation.
 
-We recommend [Poedit](https://poedit.net/) as editor of `*.po` files. You must
-specify information about yourself in the settings; put your link to Telegram
-account in the field Email if you have it.
+We recommend [Poedit](https://poedit.net/) as editor of `*.po` files. You must specify information about yourself in the settings; put the link to your Telegram account in the field Email if you have it.
 
-If you want to create new locale, run `./launch.sh create-locale <name>`. This
-command create the file `locales/<name>.po` with untranslated strings. You can
-also use Poedit to translate the bot. List of avaible locales see in [gettext
-manual](https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes).
+If you want to create new locale, run `./launch.sh create-locale <name>`. This command creates the file `locales/<name>.po` with untranslated strings. You can also use Poedit to translate the bot. List of available locales see in [gettext manual](https://www.gnu.org/software/gettext/manual/gettext.html#Language-Codes).
 After add your new locale in the file `config.lua`.
 
 * * *
@@ -175,6 +176,6 @@ Lucas Montuano, for helping me a lot in the debugging of the bot
 
 All the Admins of our [discussion groups](https://telegram.me/gbgroups) about Group Butler
 
-All the people who reported bugs and suggested new stuffs
+All the people who reported bugs and suggested new stuff
 
 Le Laide

--- a/launch.sh
+++ b/launch.sh
@@ -13,8 +13,9 @@ make_template() {
 }
 
 case $1 in bot | "")
+	source .env && export $(cut -d= -f1 .env)
 	while true; do
-		lua polling.lua
+		./polling.lua
 		sleep 10
 	done
 

--- a/lua/bot.lua
+++ b/lua/bot.lua
@@ -2,7 +2,8 @@ local api = require 'methods'
 local redis = require 'redis'
 local clr = require 'term.colors'
 local u, config, plugins, last_update, last_cron
-db = redis.connect('127.0.0.1', 6379)
+config = require 'config' -- Load configuration file.
+db = redis.connect(config.redis.host, config.redis.port)
 
 function bot_init(on_reload) -- The function run when the bot is started or reloaded.
 	if on_reload then
@@ -11,12 +12,7 @@ function bot_init(on_reload) -- The function run when the bot is started or relo
 		package.loaded.utilities = nil
 	end
 
-	config = require 'config' -- Load configuration file.
-	assert(not (config.bot_api_key == "" or not config.bot_api_key), clr.red..'Insert the bot token in config.lua -> bot_api_key'..clr.reset)
-	assert(#config.superadmins > 0, clr.red..'Insert your Telegram ID in config.lua -> superadmins'..clr.reset)
-	assert(config.log.admin, clr.red..'Insert your Telegram ID in config.lua -> log.admin'..clr.reset)
-
-	db:select(config.db or 0) --select the redis db
+	db:select(config.redis.db) --select the redis db
 
 	u = require 'utilities' -- Load miscellaneous and cross-plugin functions.
 	locale = require 'languages'
@@ -124,9 +120,9 @@ local function on_msg_receive(msg, callback) -- The fn run whenever a message is
 		-- the ! indicates UTC - https://www.lua.org/manual/5.2/manual.html#pdf-os.date
 		if not msg.text then msg.text = msg.caption or '' end
 
-		locale.language = db:get('lang:'..msg.chat.id) or 'en' --group language
+		locale.language = db:get('lang:'..msg.chat.id) or config.lang --group language
 		if not config.available_languages[locale.language] then
-			locale.language = 'en'
+			locale.language = config.lang
 		end
 
 		collect_stats(msg)

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,15 +1,59 @@
-return {
-	bot_api_key = "", --Please add your bot api key here!
-	cmd = '^[/!#]',
-	allowed_updates = {"message", "edited_message", "callback_query"},
-	db = 2, --default redis db: 0
-	superadmins = {23646077, 278941742},
-	log = {
-		chat = -1001118545630, --Your log chat, where your bot must be added!
-		admin = 23646077, --The admin.
-		stats = nil
+-- Editing this file directly is now highly disencouraged. You should instead use environment variables. This new method is a WIP, so if you need to change something which doesn't have a env var, you are encouraged to open an issue or a PR
+local json = require 'cjson'
+
+local _M =
+{
+	-- Getting updates
+	telegram =
+	{
+		token = assert(os.getenv('TG_TOKEN'), 'You must export $TG_TOKEN with your Telegram Bot API token'),
+		allowed_updates = os.getenv('TG_UPDATES') or {'message', 'edited_message', 'callback_query'},
+		polling =
+		{
+			limit = os.getenv('TG_POLLING_LIMIT'), -- Not implemented
+			timeout = os.getenv('TG_POLLING_TIMEOUT') -- Not implemented
+		},
+		webhook = -- Not implemented
+		{
+			url = os.getenv('TG_WEBHOOK_URL'),
+			certificate = os.getenv('TG_WEBHOOK_CERT'),
+			max_connections = os.getenv('TG_WEBHOOK_MAX_CON')
+		}
 	},
-	human_readable_version = '4.2.0',
+
+	-- Data
+	postgres = -- Not implemented
+	{
+		host = os.getenv('POSTGRES_HOST') or 'localhost',
+		port = os.getenv('POSTGRES_PORT') or 5432,
+		user = os.getenv('POSTGRES_USER') or 'postgres',
+		password = os.getenv('POSTGRES_PASS') or 'postgres',
+		database = os.getenv('POSTGRES_DB') or 'groupbutler',
+	},
+	redis =
+	{
+		host = os.getenv('REDIS_HOST') or 'localhost',
+		port = os.getenv('REDIS_PORT') or 6379,
+		db = os.getenv('REDIS_DB') or 0
+	},
+
+	-- Aesthetic
+	lang = os.getenv('LANG') or 'en',
+	human_readable_version = os.getenv('VERSION') or 'unknown',
+	channel = os.getenv('CHANNEL') or '@groupbutler_beta',
+	source_code = os.getenv('SOURCE') or 'https://github.com/RememberTheAir/GroupButler/tree/beta',
+	help_group = os.getenv('HELP_GROUP') or 'telegram.me/GBgroups',
+
+	-- Core
+	log =
+	{
+		chat = os.getenv('LOG_CHAT'),
+		admin = assert(os.getenv('LOG_ADMIN'), 'You must export $LOG_ADMIN with your Telegram ID'),
+		stats = os.getenv('LOG_STATS')
+	},
+	superadmins = assert(#json.decode(os.getenv('SUPERADMINS')) > 0,
+		'You must export $SUPERADMINS with a JSON array containing at least your Telegram ID'),
+	cmd = '^[/!#]',
 	bot_settings = {
 		cache_time = {
 			adminlist = 18000, --5 hours (18000s) Admin Cache time, in seconds.
@@ -25,9 +69,6 @@ return {
 		stream_commands = true,
 		admin_mode = false
 	},
-	channel = '@groupbutler_beta', --channel username with the '@'
-	source_code = 'https://github.com/RememberTheAir/GroupButler/tree/beta',
-	help_groups_link = 'telegram.me/GBgroups',
 	plugins = {
 		'onmessage', --THIS MUST BE THE FIRST: IF AN USER IS FLOODING/IS BLOCKED, THE BOT WON'T GO THROUGH PLUGINS
 		'antispam', --SAME OF onmessage.lua
@@ -183,3 +224,11 @@ return {
 		d2 = {'bot:groupsid', 'bot:groupsid:removed', 'tempbanned', 'bot:blocked', 'remolden_chats'} --remolden_chats: chat removed with $remold command
 	}
 }
+
+local multipurpose_plugins = os.getenv('MULTIPURPOSE_PLUGINS')
+if multipurpose_plugins then
+	_M.multipurpose_plugins = assert(json.decode(multipurpose_plugins),
+		'$MULTIPURPOSE_PLUGINS must be a JSON array or empty.')
+end
+
+return _M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -47,7 +47,7 @@ local _M =
 	-- Core
 	log =
 	{
-		chat = os.getenv('LOG_CHAT'),
+		chat = assert(os.getenv('LOG_CHAT'), 'You must export $LOG_CHAT with the numerical ID of the log chat'),
 		admin = assert(os.getenv('LOG_ADMIN'), 'You must export $LOG_ADMIN with your Telegram ID'),
 		stats = os.getenv('LOG_STATS')
 	},
@@ -228,7 +228,7 @@ local _M =
 local multipurpose_plugins = os.getenv('MULTIPURPOSE_PLUGINS')
 if multipurpose_plugins then
 	_M.multipurpose_plugins = assert(json.decode(multipurpose_plugins),
-		'$MULTIPURPOSE_PLUGINS must be a JSON array or empty.')
+		'$MULTIPURPOSE_PLUGINS must be a JSON array or empty')
 end
 
 return _M

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -38,7 +38,7 @@ local _M =
 	},
 
 	-- Aesthetic
-	lang = os.getenv('LANG') or 'en',
+	lang = os.getenv('DEFAULT_LANG') or 'en',
 	human_readable_version = os.getenv('VERSION') or 'unknown',
 	channel = os.getenv('CHANNEL') or '@groupbutler_beta',
 	source_code = os.getenv('SOURCE') or 'https://github.com/RememberTheAir/GroupButler/tree/beta',

--- a/lua/methods.lua
+++ b/lua/methods.lua
@@ -5,7 +5,7 @@ local config = require 'config'
 local clr = require 'term.colors'
 local api_errors = require 'api_bad_requests'
 
-local BASE_URL = 'https://api.telegram.org/bot' .. config.bot_api_key
+local BASE_URL = 'https://api.telegram.org/bot' .. config.telegram.token
 
 local api = {}
 
@@ -118,7 +118,8 @@ function api.getUpdates(offset)
 end
 
 function api.firstUpdate()
-	local url = BASE_URL .. '/getUpdates?timeout=3600&limit=1&allowed_updates='..JSON.encode(config.allowed_updates)
+	local url = BASE_URL .. '/getUpdates?timeout=3600&limit=1&allowed_updates=' ..
+		JSON.encode(config.telegram.allowed_updates)
 
 	return sendRequest(url)
 end

--- a/lua/plugins/banhammer.lua
+++ b/lua/plugins/banhammer.lua
@@ -21,7 +21,7 @@ local function get_motivation(msg)
 end
 
 local function set_lang(chat_id)
-	locale.language = db:get('lang:'..chat_id) or 'en' --group language
+	locale.language = db:get('lang:'..chat_id) or config.lang --group language
 	if not config.available_languages[locale.language] then
 		locale.language = 'en'
 	end

--- a/lua/plugins/mediasettings.lua
+++ b/lua/plugins/mediasettings.lua
@@ -5,7 +5,7 @@ local api = require 'methods'
 local plugin = {}
 
 local function doKeyboard_media(chat_id)
-	if not ln then ln = 'en' end
+	if not ln then ln = config.lang end
 	local keyboard = {}
 	keyboard.inline_keyboard = {}
 	for media, default_status in pairs(config.chat_settings['media']) do

--- a/lua/plugins/service.lua
+++ b/lua/plugins/service.lua
@@ -10,7 +10,7 @@ function plugin.onTextMessage(msg, blocks)
 
 	if blocks[1] == 'new_chat_member:bot' or blocks[1] == 'migrate_from_chat_id' then
 		-- set the language
-		--[[locale.language = db:get(string.format('lang:%d', msg.from.id)) or 'en'
+		--[[locale.language = db:get(string.format('lang:%d', msg.from.id)) or config.lang
 		if not config.available_languages[locale.language] then
 			locale.language = 'en'
 		end]]

--- a/lua/utilities.lua
+++ b/lua/utilities.lua
@@ -615,7 +615,7 @@ end
 function utilities.getSettings(chat_id)
 	local hash = 'chat:'..chat_id..':settings'
 
-	local lang = db:get('lang:'..chat_id) or 'en' -- group language
+	local lang = db:get('lang:'..chat_id) or config.lang -- group language
 	local message = _("Current settings for *the group*:\n\n")
 			.. _("*Language*: %s\n"):format(config.available_languages[lang])
 

--- a/polling.lua
+++ b/polling.lua
@@ -1,2 +1,4 @@
+#!/usr/bin/env lua
+
 package.path=package.path .. ';./lua/?.lua'
 require 'bot'


### PR DESCRIPTION
How many times have you seen people committing their bot tokens? Yeah, this fixes that, while keeping config.lua mostly static and is the foundation of…

Overview:
- Move most (but not all) settings to env vars
- Load variables from .env nicely when using  `./launch.sh`
- Add config for future updates (webhook, postgres)
- Update readme