### PR TITLE
Docker and GitLab CI support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 .env
+docker-compose.*.yml
 *.sh
 *.json
 *.tar
 locales/
 
+!docker-compose.override.yml
 !install.sh
 !launch.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,14 +4,10 @@ stages:
   # - test
   - deploy
 
-variables:
-  DOCKER_DRIVER: overlay2
-
 lint:
-  image: yangm97/luacheck
   stage: lint
   script:
-    - luacheck .
+    - docker run --rm -v $(pwd):/data yangm97/luacheck || [ "$?" -le "1" ]
 
 build:
   stage: build
@@ -27,6 +23,10 @@ build:
     - production
 
 deploy:
+  environment:
+    name: $CI_COMMIT_REF_SLUG
+  tags:
+    - manager
   stage: deploy
   variables:
     IMAGE: $CI_REGISTRY_IMAGE

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,6 +14,9 @@ build:
   variables:
     IMAGE: $CI_REGISTRY_IMAGE
     TAG: $CI_COMMIT_REF_SLUG
+  before_script:
+    - apk add --no-cache py-pip
+    - pip install docker-compose
   script:
     - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
     - docker-compose build

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -36,7 +36,7 @@ deploy:
     TAG: $CI_COMMIT_REF_SLUG
   script:
     - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
-    - docker stack deploy $CI_COMMIT_REF_SLUG -c docker-compose.yml
+    - docker stack deploy --with-registry-auth $CI_COMMIT_REF_SLUG -c docker-compose.yml
   only:
     - staging
     - production

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,39 @@
+stages:
+  - lint
+  - build
+  # - test
+  - deploy
+
+variables:
+  DOCKER_DRIVER: overlay2
+
+lint:
+  image: yangm97/luacheck
+  stage: lint
+  script:
+    - luacheck .
+
+build:
+  stage: build
+  variables:
+    IMAGE: $CI_REGISTRY_IMAGE
+    TAG: $CI_COMMIT_REF_SLUG
+  script:
+    - docker login -u "gitlab-ci-token" -p "$CI_JOB_TOKEN" $CI_REGISTRY
+    - docker-compose build
+    - docker-compose push
+  only:
+    - staging
+    - production
+
+deploy:
+  stage: deploy
+  variables:
+    IMAGE: $CI_REGISTRY_IMAGE
+    TAG: $CI_COMMIT_REF_SLUG
+  script:
+    - docker login -u gitlab-ci-token -p $CI_JOB_TOKEN $CI_REGISTRY
+    - docker stack deploy $CI_COMMIT_REF_SLUG -c docker-compose.yml
+  only:
+    - staging
+    - production

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM yangm97/lua:latest
+
+WORKDIR /srv/app
+
+CMD ["polling.lua"]
+
+ARG DEPS_NATIVE="curl-dev"
+
+ARG DEPS_ROCKS="luasec luasocket redis-lua lua-term serpent dkjson Lua-cURL"
+
+RUN apk add --no-cache $DEPS_NATIVE && \
+    for ROCK in $DEPS_ROCKS; do luarocks install $ROCK; done
+
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM yangm97/lua:latest
+FROM yangm97/lua:5.2-alpine
 
 WORKDIR /srv/app
 

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,17 @@
+version: '3.3'
+
+services:
+  groupbutler:
+    build: .
+    environment:
+      - REDIS_HOST=redis
+    volumes:
+      - ./locales:/srv/app/locales
+      - ./lua:/srv/app/lua
+      - ./polling.lua:/polling.lua
+
+  redis:
+    command: --save "" --appendonly no
+    image: redis:alpine
+    ports:
+      - "6379:6379"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -3,8 +3,11 @@ version: '3.3'
 services:
   groupbutler:
     build: .
+    depends_on:
+      - redis
     environment:
       - REDIS_HOST=redis
+    restart: on-failure
     volumes:
       - ./locales:/srv/app/locales
       - ./lua:/srv/app/lua
@@ -13,5 +16,6 @@ services:
   redis:
     command: --save "" --appendonly no
     image: redis:alpine
+    restart: on-failure
     ports:
       - "6379:6379"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,4 +28,4 @@ services:
       - TG_WEBHOOK_CERT
       - TG_WEBHOOK_MAX_CON
     image: ${IMAGE:-groupbutler}:${TAG:-latest}
-    tty: true
+    # tty: true # needed when using lua 5.1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.3'
+
+services:
+  groupbutler:
+    environment:
+      - CHANNEL
+      - DEFAULT_LANG
+      - HELP_GROUP
+      - LOG_CHAT
+      - LOG_ADMIN
+      - LOG_STATS
+      - MULTIPURPOSE_PLUGINS
+      - POSTGRES_HOST
+      - POSTGRES_PORT
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      - REDIS_HOST
+      - REDIS_PORT
+      - REDIS_DB
+      - SOURCE
+      - SUPERADMINS
+      - TG_TOKEN
+      - TG_UPDATES
+      - TG_POLLING_LIMIT
+      - TG_POLLING_TIMEOUT
+      - TG_WEBHOOK_URL
+      - TG_WEBHOOK_CERT
+      - TG_WEBHOOK_MAX_CON
+    image: ${IMAGE:-groupbutler}:${TAG:-latest}
+    tty: true

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -209,7 +209,8 @@ local _M =
 		rules_on_join = 'off',
 		reports = 'off'
 	},
-	chat_hashes = {'extra', 'info', 'links', 'warns', 'mediawarn', 'spamwarns', 'blocked', 'report', 'defpermissions', 'defpermduration'},
+	chat_hashes = {'extra', 'info', 'links', 'warns', 'mediawarn', 'spamwarns', 'blocked', 'report', 'defpermissions',
+		'defpermduration'},
 	chat_sets = {'whitelist'},--, 'mods'},
 	bot_keys = {
 		d3 = {'bot:general', 'bot:usernames', 'bot:chat:latsmsg'},

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -1,12 +1,24 @@
 -- Editing this file directly is now highly disencouraged. You should instead use environment variables. This new method is a WIP, so if you need to change something which doesn't have a env var, you are encouraged to open an issue or a PR
 local json = require 'dkjson'
+local open = io.open
+
+local function read_file(path)
+	local file = open(path, "rb")
+	if not file then return nil end
+	local content = file:read "*a"
+	file:close()
+	return content
+end
+
+local secret = '/run/secrets/'
 
 local _M =
 {
 	-- Getting updates
 	telegram =
 	{
-		token = assert(os.getenv('TG_TOKEN'), 'You must export $TG_TOKEN with your Telegram Bot API token'),
+		token = assert(read_file(secret..'telegram/token') or os.getenv('TG_TOKEN'),
+			'You must export $TG_TOKEN with your Telegram Bot API token'),
 		allowed_updates = os.getenv('TG_UPDATES') or {'message', 'edited_message', 'callback_query'},
 		polling =
 		{
@@ -16,7 +28,7 @@ local _M =
 		webhook = -- Not implemented
 		{
 			url = os.getenv('TG_WEBHOOK_URL'),
-			certificate = os.getenv('TG_WEBHOOK_CERT'),
+			certificate = read_file(secret..'telegram/webhook/certificate') or os.getenv('TG_WEBHOOK_CERT'),
 			max_connections = os.getenv('TG_WEBHOOK_MAX_CON')
 		}
 	},
@@ -27,7 +39,7 @@ local _M =
 		host = os.getenv('POSTGRES_HOST') or 'localhost',
 		port = os.getenv('POSTGRES_PORT') or 5432,
 		user = os.getenv('POSTGRES_USER') or 'postgres',
-		password = os.getenv('POSTGRES_PASS') or 'postgres',
+		password = read_file(secret..'postgres/password') or os.getenv('POSTGRES_PASSWORD') or 'postgres',
 		database = os.getenv('POSTGRES_DB') or 'groupbutler',
 	},
 	redis =

--- a/lua/config.lua
+++ b/lua/config.lua
@@ -2,22 +2,20 @@
 local json = require 'dkjson'
 local open = io.open
 
-local function read_file(path)
-	local file = open(path, "rb")
+local function read_secret(path)
+	local file = open('/run/secrets/'..path, "rb")
 	if not file then return nil end
 	local content = file:read "*a"
 	file:close()
 	return content
 end
 
-local secret = '/run/secrets/'
-
 local _M =
 {
 	-- Getting updates
 	telegram =
 	{
-		token = assert(read_file(secret..'telegram/token') or os.getenv('TG_TOKEN'),
+		token = assert(read_secret('telegram/token') or os.getenv('TG_TOKEN'),
 			'You must export $TG_TOKEN with your Telegram Bot API token'),
 		allowed_updates = os.getenv('TG_UPDATES') or {'message', 'edited_message', 'callback_query'},
 		polling =
@@ -28,7 +26,7 @@ local _M =
 		webhook = -- Not implemented
 		{
 			url = os.getenv('TG_WEBHOOK_URL'),
-			certificate = read_file(secret..'telegram/webhook/certificate') or os.getenv('TG_WEBHOOK_CERT'),
+			certificate = read_secret('telegram/webhook/certificate') or os.getenv('TG_WEBHOOK_CERT'),
 			max_connections = os.getenv('TG_WEBHOOK_MAX_CON')
 		}
 	},
@@ -39,7 +37,7 @@ local _M =
 		host = os.getenv('POSTGRES_HOST') or 'localhost',
 		port = os.getenv('POSTGRES_PORT') or 5432,
 		user = os.getenv('POSTGRES_USER') or 'postgres',
-		password = read_file(secret..'postgres/password') or os.getenv('POSTGRES_PASSWORD') or 'postgres',
+		password = read_secret('postgres/password') or os.getenv('POSTGRES_PASSWORD') or 'postgres',
 		database = os.getenv('POSTGRES_DB') or 'groupbutler',
 	},
 	redis =

--- a/lua/languages.lua
+++ b/lua/languages.lua
@@ -4,7 +4,7 @@ local strings = {} -- internal array with translated strings
 
 -- Evaluates the Lua's expression
 local function eval(str)
-	return load('return ' .. str)()
+	return loadstring('return ' .. str)()
 end
 
 -- Parses the file with translation and returns a table with English strings as


### PR DESCRIPTION
Allowing the bot to be tested and deployed from within a simple `docker-compose up` command. This removes the dependency hell, keeps our machines clean, deprecate “works on my machine” etc.
Along with docker-compose.yml used for testing, there are also examples on how to use it on production and .gitlab-ci.yml for continuous integration.
Deploying GroupButler can now be as easy as cloning (on gitlab) and setting variables.

EDIT: Using alpine linux and lua 5.2, should be ready to go now