### PR TITLE
Update banhammer.lua

### DIFF
--- a/lua/plugins/banhammer.lua
+++ b/lua/plugins/banhammer.lua
@@ -123,7 +123,7 @@ function plugin.onTextMessage(msg, blocks)
 				else
 					local result = api.getChatMember(chat_id, user_id)
 					local text
-					if result.status ~= 'kicked' then
+					if result.result.status ~= 'kicked' then
 						text = i18n("This user is not banned!")
 					else
 						api.unbanUser(chat_id, user_id)


### PR DESCRIPTION
I made a mistake. result has a result field which contains a status field. Just like this:
{
    "ok": true,
    "result": {
        "user": {
            "id": xxxxxxxx,
            "is_bot": false,
            "first_name": "yyyyyyyy",
            "username": "zzzzzzz"
        },
        "status": "kicked",
        "until_date": 0
    }
}
Please test this, ban someone, unban (and see it fails).
Then apply this patch and see it unbans. Again sorry for inconvenience.